### PR TITLE
Add TypeAnalysis interface

### DIFF
--- a/src/main/scala/analysis/TypeAnalysis.scala
+++ b/src/main/scala/analysis/TypeAnalysis.scala
@@ -1,0 +1,31 @@
+package org.tud.sse.metrics
+package analysis
+
+import input.CliParser.OptionMap
+
+import org.opalj.br.ObjectType
+import org.opalj.br.analyses.Project
+
+import java.net.URL
+import scala.util.{Success, Try}
+
+trait TypeAnalysis extends SingleFileAnalysis {
+
+  override final def analyzeProject(project: Project[URL],
+                                    customOptions: OptionMap): Try[Iterable[MetricValue]] = {
+    val typeResults = project
+      .projectClassFiles
+      .map(_.thisType)
+      .map( typeObj => analyzeType(typeObj, project, customOptions))
+
+    if(typeResults.exists(_.isFailure)){
+      typeResults.find(_.isFailure).get
+    } else {
+      Success(typeResults.flatMap(_.get))
+    }
+
+  }
+
+  def analyzeType(typeObj: ObjectType, project: Project[URL], customOptions: OptionMap): Try[Iterable[MetricValue]]
+
+}


### PR DESCRIPTION
**Reason for this PR**
As mentioned in #25 , we want to provide an interface for analyzing classes.

**Changes in this PR**
Added `TypeAnalysis` which extends `SingleFileAnalysis` and provides an entrypoint for analyzing all `ObjectType`s of a given project. Note that `ObjectType` in this context is corresponding to classes inside a project.

**Links**
Closes #25. 