### PR TITLE
Add Assembly Plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,15 @@ scalaVersion := "2.12.14"
 
 idePackagePrefix := Some("org.tud.sse.metrics")
 
+assembly / mainClass := Some("org.tud.sse.metrics.impl.ApplicationEntryPoint")
+assembly / assemblyJarName := "analysis-application.jar"
+
+assemblyMergeStrategy := {
+  case x: String if x.toLowerCase.contains("manifest.mf") => MergeStrategy.discard
+  case x: String if x.toLowerCase.endsWith(".conf") => MergeStrategy.concat
+  case x => MergeStrategy.first
+}
+
 libraryDependencies += "com.opencsv" % "opencsv" % "5.5"
 
 val opalVersion = "4.0.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.jetbrains" % "sbt-ide-settings" % "1.1.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")

--- a/src/main/scala/impl/ApplicationEntryPoint.scala
+++ b/src/main/scala/impl/ApplicationEntryPoint.scala
@@ -1,0 +1,16 @@
+package org.tud.sse.metrics
+package impl
+
+object ApplicationEntryPoint {
+
+  final def main(args: Array[String]): Unit = {
+
+    if (!args.contains("--multi-file")) {
+      SingleFileAnalysisApplication.main(args)
+    } else {
+      MultiFileAnalysisApplication.main(args.filterNot(_.equals("--multi-file")))
+    }
+
+  }
+
+}


### PR DESCRIPTION
**Grund für den PR**
Wie grade im Meeting besprochen war das SBT `assembly` Plugin noch nicht konfiguriert, darum konnte kein sogenanntes *Fat JAR* (ein JAR file mit allen nötigen Dependencies) generiert werden. Ohne dies kann keine sinnvolle Evaluation erfolgen.

**Änderungen in diesem PR**
Das Assembly Plugin wurde zum Buildprozess hinzugefügt und konfiguriert. Außerdem wurde der `ApplicationEntryPoint` hinzugefügt. Das ist eine Klasse, die dafür sorgt dass man sowohl die `SingleFileAnalysisApplication` als auch die `MultiFileAnalysisApplication` per Kommandozeile ausführen kann. Konkret sind jetzt folgende Schritt möglich / nötig:

* `sbt assembly` generiert ein *Fat JAR* mit Namen `analysis-application.jar` im Verzeichnis `target/scala-2.12`
* Mit dem *Fat JAR* können beide Analyse-Arten ausgeführt werden:
    * `java -jar analysis-application.jar <parameter hier>` führt die `org.tud.sse.metrics.impl.SingleFileAnalysisApplication` mit den gegebenen Parametern aus (Alternativ: `java -jar analysis-application.jar org.tud.sse.metrics.impl.SingleFileAnalysisApplication <parameter hier>`)
    * `java -jar analysis-application.jar --multi-file <parameter hier>` führt die `org.tud.sse.metrics.impl.MultiFileAnalysisApplication` mit den gegebenen Parametern aus (Alternativ: `java -jar analysis-application.jar org.tud.sse.metrics.impl.MultiFileAnalysisApplication <parameter hier>`)

