### PR TITLE
- Bug Fixes on TCC LCC - (Related to: public abstract methods)

### DIFF
--- a/src/main/scala/impl/group3/LCCAnalysis.scala
+++ b/src/main/scala/impl/group3/LCCAnalysis.scala
@@ -33,7 +33,7 @@ class LCCAnalysis extends SingleFileAnalysis {
         val numberOfPossibleConnections = (publicMethodsCount * (publicMethodsCount-1) / 2).toDouble
 
         //calculating the direct connections and save all of them in the map in order to find the indirect connections in the next step
-        val allPublicMethods= c.methods.filter(_.isPublic)
+        val allPublicMethods= c.methods.filter(_.isPublic).filter(_.isNotAbstract)
         var directlyConnectedMethodPairs = 0.toDouble
         val map = scala.collection.mutable.Map[String, List[String]]()
         if(c.fields.nonEmpty && numberOfPossibleConnections!=0){

--- a/src/main/scala/impl/group3/TCCAnalysis.scala
+++ b/src/main/scala/impl/group3/TCCAnalysis.scala
@@ -34,7 +34,7 @@ class TCCAnalysis extends SingleFileAnalysis {
         /**
          * calculating the number of directly connected method pairs
          */
-        val allPublicMethods= c.methods.filter(_.isPublic)
+        val allPublicMethods= c.methods.filter(_.isPublic).filter(_.isNotAbstract)
 //        println("All public method's body: " + c.methods.filter(_.isPublic).foreach(m => println(m.body + "\n")))
         var directlyConnectedMethodPairs = 0.toDouble
         if(c.fields.nonEmpty && numberOfPossibleConnections!=0){


### PR DESCRIPTION
During the evaluation phase, we found out that 2 of our metrics (TCC & LCC) would throw exceptions while trying to read the body of abstract methods. As mentioned in the meeting, the issue is now resolved and we could get our performance results.
However, the changes are yet to be merged to the develop branch.

